### PR TITLE
Update for 4.03

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,5 @@
+PKG core async yojson bignum
+S app/**
+S lib/**
+B app/**
+B lib/**

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ mlbuild
       libraries          : string list sexp_option;
       (* ocamlfind libraries *)
       external_libraries : string list sexp_option;
-      (* other libraries to specify to the linker *)
+      (* other libraries to specify to the linker via -l *)
       foreign_libraries  : string list sexp_option;
+      (* non-ocamlfind ocaml libraries (.cmxa) to use *)
+      classig_libraries  : string list sexp_option;
     } with sexp

--- a/lib/sample/std.ml
+++ b/lib/sample/std.ml
@@ -1,4 +1,4 @@
-open Core.Std  let () = _squelch_unused_module_warning_
+open! Core.Std
 open Async.Std
 
 let do_something_awesome () =

--- a/ocamlfind-wrap
+++ b/ocamlfind-wrap
@@ -1,0 +1,3 @@
+#!/bin/bash
+eval `opam config env`
+exec ocamlfind "$@" 2> >(sed -e "s#^File \"#File \"${PWD}/#" >&2)


### PR DESCRIPTION
- renamed classic_libs to classic_libraries so that all names are uniform
