### PR TITLE
bringing jengaroot.ml up to date with latest jenga

### DIFF
--- a/jengaroot.ml
+++ b/jengaroot.ml
@@ -561,7 +561,7 @@ let scheme ~dir =
   in
   Scheme.all
     [ Scheme.sources [ Path.relative ~dir "mlbuild"; Path.relative ~dir "resbuild" ]
-    ; (Scheme.rules_dep rules) ]
+    ; Scheme.rules_dep rules ]
 ;;
 
 let setup () =


### PR DESCRIPTION
Dep.glob_listing was causing cyclic dependencies (possibly because of
changes in jenga 114.02+109), so now the maybe more appropriate
Dep.fs_glob_listing is used.

Scheme.exclude is no longer available since jenga 114.02+109, therefore
instead the mlbuild/resbuild files are marked as source explicitly.

Dep.bind takes the function as a labeled argument f since jenga
114.04+40.

Works with the latest version of jenga (114.04+57, ce5a0c).
